### PR TITLE
Showing error when 404 is received

### DIFF
--- a/projects/sartography-workflow-lib/package.json
+++ b/projects/sartography-workflow-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sartography-workflow-lib",
-  "version": "0.0.276",
+  "version": "0.0.277",
   "peerDependencies": {
     "@angular/common": "^8.2.14",
     "@angular/core": "^8.2.14",

--- a/projects/sartography-workflow-lib/src/lib/components/api-errors/api-errors.component.html
+++ b/projects/sartography-workflow-lib/src/lib/components/api-errors/api-errors.component.html
@@ -13,7 +13,7 @@
     <div mat-line *ngIf="e.tag">Tag: {{e.tag}}</div>
     <ng-container *ngIf="e.message">
       <div mat-line>
-        <code *ngIf="e.message">{{e.message}}</code>
+        <code *ngIf="e.message">{{e.message}} - Please try again</code>
       </div>
     </ng-container>
   </mat-list-item>

--- a/projects/sartography-workflow-lib/src/lib/services/error-interceptor.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/error-interceptor.ts
@@ -37,7 +37,7 @@ export class ErrorInterceptor implements HttpInterceptor {
       }
 
       // Display API Error
-      if (err.status === 400 || err.status === 500) {
+      if (err.status === 400 || err.status === 404 || err.status === 500) {
         this.zone.run(() => {
           this.bottomSheet.open(ApiErrorsComponent, {data: {apiErrors: [err.error]}});
         });


### PR DESCRIPTION
404 error was not being accounted for in the automatic error dispatcher to let the user know something failed.