### PR TITLE
when comparing two enums just look at the value, not at the objects a…

### DIFF
--- a/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
@@ -156,7 +156,7 @@ export class ToFormlyPipe implements PipeTransform {
           // the value attribute of the field. Yes, it's confusing, but it allows us to access the label
           // of the option so we can display it later.
           resultField.templateOptions.valueProp = (option) => option;
-          resultField.templateOptions.compareWith = (o1, o2) => isEqual(o1, o2);
+          resultField.templateOptions.compareWith = (o1, o2) => isEqual(o1.value, o2.value);
           break;
         case 'string':
           resultField.type = 'input';


### PR DESCRIPTION
…s a whole.