### PR TITLE
Enums were having a very hard time updating based on the default value.

### DIFF
--- a/projects/sartography-workflow-lib/src/lib/modules/forms/autocomplete-field/autocomplete-field.component.html
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/autocomplete-field/autocomplete-field.component.html
@@ -1,5 +1,5 @@
 <!-- this is were the real value goes. -->
-<input type="hidden" [formControl]="formControl">
+<input type="hidden" [formControl]="formControl" (ngModelChange)="valueChanged($event)">
 
 <!-- this input is used to handle the autocomplete and display things correctly -->
 <input

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/autocomplete-field/autocomplete-field.component.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/autocomplete-field/autocomplete-field.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {AfterViewInit, Component, OnInit} from '@angular/core';
 import {FieldType} from '@ngx-formly/material';
 import {EMPTY, Observable} from 'rxjs';
 import {debounceTime, startWith, switchMap, tap} from 'rxjs/operators';
@@ -12,7 +12,7 @@ import {MatAutocompleteSelectedEvent} from '@angular/material/autocomplete';
   templateUrl: './autocomplete-field.component.html',
   styleUrls: ['./autocomplete-field.component.scss']
 })
-export class AutocompleteFieldComponent extends FieldType implements OnInit {
+export class AutocompleteFieldComponent extends FieldType implements OnInit, AfterViewInit {
   filter: Observable<Object[]>;
   selectedObject: Object; // The full object returned by the api, when one is selected.
   label: string;
@@ -28,9 +28,10 @@ export class AutocompleteFieldComponent extends FieldType implements OnInit {
     super();
   }
 
+
+
   ngOnInit(): void {
     super.ngOnInit();
-
 
     this.fileParams = {
       study_id: this.to.study_id,
@@ -39,18 +40,17 @@ export class AutocompleteFieldComponent extends FieldType implements OnInit {
       form_field_key: this.key as string,
     };
 
-    if(this.value) {
-      this.setSelectionFromValue(this.value);
-    }
-
     this.filter = this.textInputControl.valueChanges.pipe(
       debounceTime(500),
-      startWith(''),
+      startWith(''), // Initially execute this with an empty string to get some results back.
       switchMap<string, Observable<Object[]>>(term => {
         if(term === this.selectedObject) {
-          return EMPTY;  // Don't try to saerch for the selected object, only do this for strings.
+          return EMPTY;  // Don't try to search for the selected object, only do this for strings.
         }
-        this.value = "invalid";
+        if(term.length < 3) {
+          term = "";  // Return all the results if we don't have a valid term yet ...
+        }
+
         this.loading = true;
         return this.api.lookupFieldOptions(term, this.fileParams, null, this.to.limit);
       })
@@ -61,6 +61,11 @@ export class AutocompleteFieldComponent extends FieldType implements OnInit {
       this.numResults = results.length;
       this.selectedObject = null;
     })
+  }
+
+  ngAfterViewInit(): void {
+    super.ngAfterViewInit();
+    this.setSelectionFromValue(this.value)
   }
 
   state() {
@@ -75,14 +80,21 @@ export class AutocompleteFieldComponent extends FieldType implements OnInit {
     }
   }
 
-  setSelectionFromValue(value: string) {
+  valueChanged(newValue) {
+    this.setSelectionFromValue(newValue)
+  }
+
+  setSelectionFromValue(value) {
+    if(this.textInputControl.value == value || value == false || value == null) {
+      return;
+    }
+
     this.api.lookupFieldOptions('', this.fileParams, value, 1).subscribe(hits => {
       if(hits.length > 0) {
         this.selectedObject = hits[0]
         this.label = hits[0][this.to.label_column];
-        this.value = value;
       } else {
-        console.error("Failed to locate previous selection for auto-complete, leaving blank.")
+        console.error("Failed to locate selection '" + value + "' for auto-complete, leaving blank.")
       }
     })
   }
@@ -90,8 +102,6 @@ export class AutocompleteFieldComponent extends FieldType implements OnInit {
   newSelection(selected: MatAutocompleteSelectedEvent) {
     this.selectedObject = selected.option.value;
     this.value = this.selectedObject[this.to.value_column];
-    console.log("Selected Object is ", this.selectedObject);
-    console.log("Value is ", this.value);
   }
 
   displayFn(lookupData: Object): string {

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/sartography-forms.module.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/sartography-forms.module.ts
@@ -57,12 +57,14 @@ import {
 } from './validators/formly.validator';
 import { RepeatSectionConfirmDialogComponent } from './repeat-section-confirm-dialog/repeat-section-confirm-dialog.component';
 import {MatProgressSpinnerModule, MatSpinner} from '@angular/material/progress-spinner';
+import {ConfigOption} from '@ngx-formly/core/lib/services/formly.config';
 
 
 @Injectable()
 export class AppFormlyConfig {
   public static config = {
     extras: {
+      checkExpressionOn: 'modelChange' as ConfigOption['extras']['checkExpressionOn'],
       showError: ShowError,
     },
     types: [

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/validators/formly.validator.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/validators/formly.validator.ts
@@ -76,7 +76,6 @@ export function AutocompleteValidator(control: FormControl): ValidationErrors {
   );
 
   if (isRequired && !control.value) {
-    console.log("Yes, the control has a value:", control.value);
     return {required: true};
   }
   if (control.value === 'invalid') {

--- a/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
@@ -533,16 +533,17 @@ export class ToFormlyPipe implements PipeTransform {
    * You can pass an optional method, which should be called when the result completes.
    */
   protected getPythonEvalFunction(field: BpmnFormJsonField, p: BpmnFormJsonFieldProperty, defaultValue = false, method = null) {
+    // Establish some variables to be added to the form state.
+    const variableKey = field.id + '_' + p.id;  // The actual value we want to return
+    const variableSubjectKey = field.id + '_' + p.id + '_subject'; // A subject to add api calls to.
+    const variableSubscriptionKey = field.id + '_' + p.id + '_subscription'; // a debounced subscription.
+    const variableCountCalls = field.id + '_' + p.id + '_count'; // Total number of times called.
+
+    // Here is the function to execute to get the value.
     return (model: any, formState: any, fieldConfig: FormlyFieldConfig) => {
       if (!formState) {
         formState = {};
       }
-
-      // Establish some variables to be added to the form state.
-      const variableKey = field.id + '_' + p.id;  // The actual value we want to return
-      const variableSubjectKey = field.id + '_' + p.id + '_subject'; // A subject to add api calls to.
-      const variableSubscriptionKey = field.id + '_' + p.id + '_subscription'; // a debounced subscription.
-      const variableCountCalls = field.id + '_' + p.id + '_count';
 
       // A bit of code to warn us when we are calling this 1000's of times.
       if(!(variableCountCalls in formState)) {
@@ -554,7 +555,6 @@ export class ToFormlyPipe implements PipeTransform {
             "Current count " + formState[variableCountCalls] )
         }
       }
-
 
       // Do this only the first time it is called to establish some subjects and subscriptions.
       // Set up a variable that can be returned, and a variable subject that can be debounced,
@@ -622,6 +622,7 @@ export class ToFormlyPipe implements PipeTransform {
         formState[variableSubjectKey].next({expression: p.value, data, key});
       }
       // We immediately return the variable, but it might change due to the above observable.
+      console.log("Returning ", formState[variableKey][key]);
       return formState[variableKey][key];
     };
   }


### PR DESCRIPTION
This is mostly fixed in the frontend, by properly clearing out the formstate between forms.
But we made some fixes here to handle updates in autocomplete, so we recognize when a value changes.
checkExpressionOn: 'modelChange' is frequently recommended, but I was always getting a compile time error trying to get it in there, finally figured out how to write it.