### PR TITLE
Addendum to #294 - Single checkbox Boolean Property

### DIFF
--- a/projects/sartography-workflow-lib/src/lib/modules/forms/sartography-forms.module.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/sartography-forms.module.ts
@@ -53,7 +53,9 @@ import {
   RepeatSectionValidatorMessage,
   ShowError,
   UrlValidator,
-  UrlValidatorMessage
+  UrlValidatorMessage,
+  CheckedValidator,
+  CheckedValidatorMessage,
 } from './validators/formly.validator';
 import { RepeatSectionConfirmDialogComponent } from './repeat-section-confirm-dialog/repeat-section-confirm-dialog.component';
 import {MatProgressSpinnerModule, MatSpinner} from '@angular/material/progress-spinner';
@@ -83,6 +85,8 @@ export class AppFormlyConfig {
       {name: 'file', validation: FileFieldValidator},
       {name: 'files', validation: FileUploadValidator},
       {name: 'repeat', validation: RepeatSectionValidator},
+      {name: 'checked', validation: CheckedValidator},
+
     ],
     validationMessages: [
       {name: 'phone', message: PhoneValidatorMessage},
@@ -96,6 +100,7 @@ export class AppFormlyConfig {
       {name: 'required', message: 'This field is required.'},
       {name: 'min', message: MinValidationMessage},
       {name: 'max', message: MaxValidationMessage},
+      {name: 'checked', message: CheckedValidatorMessage},
     ],
     wrappers: [
       {name: 'panel', component: PanelWrapperComponent},

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/validators/formly.validator.spec.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/validators/formly.validator.spec.ts
@@ -65,6 +65,17 @@ describe('Formly Validators', () => {
     expect(Validators.UrlValidatorMessage(err, field)).toContain('bad_url');
   });
 
+  it('should validate a single boolean checkbox', () => {
+    control.setValue('null');
+    expect(Validators.CheckedValidator(control)).toBeNull();
+
+    control.setValue(false);
+    expect(Validators.CheckedValidator(control)).toEqual({checked: true});
+
+    control.setValue(true);
+    expect(Validators.CheckedValidator(control)).toBeNull();
+  })
+
   it('should validate phone numbers', () => {
     const badPhones = [
       'not a phone number',

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/validators/formly.validator.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/validators/formly.validator.ts
@@ -30,6 +30,14 @@ export function PhoneValidatorMessage(err, field: FormlyFieldConfig) {
   return `"${field.formControl.value}" is not a valid phone number`;
 }
 
+export function CheckedValidator(control: FormControl): ValidationErrors {
+   return !control.value == true ? {checked:true} : null;
+}
+
+export function CheckedValidatorMessage() {
+  return `You must check this box to continue.`;
+}
+
 export function MinValidationMessage(err, field) {
   return `This value should be more than ${field.templateOptions.min}`;
 }

--- a/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
@@ -196,6 +196,7 @@ export class ToFormlyPipe implements PipeTransform {
             resultField.type = 'checkbox';
             resultField.defaultValue = false;
             resultField.templateOptions = { indeterminate: false };
+            resultField.validators = {validation: ['checked']};
             break;
           }
           else if (!field.properties.find(x => x.id === 'boolean_type')) {


### PR DESCRIPTION
dunno where the original branch was BUT what this one does, is put a validator on single checkboxes. To where you must 'check' it in order to continue. Is used for things like 'Terms and Conditions' acknowledgement.