### PR TITLE
Fixes to panel and repeat

### DIFF
--- a/projects/sartography-workflow-lib/package.json
+++ b/projects/sartography-workflow-lib/package.json
@@ -1,5 +1,5 @@
 {
   "name": "sartography-workflow-lib",
-  "version": "0.0.599",
+  "version": "0.0.600",
   "dependencies": {}
 }

--- a/projects/sartography-workflow-lib/package.json
+++ b/projects/sartography-workflow-lib/package.json
@@ -1,5 +1,5 @@
 {
   "name": "sartography-workflow-lib",
-  "version": "0.0.597",
+  "version": "0.0.599",
   "dependencies": {}
 }

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/panel-wrapper/panel-wrapper.component.html
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/panel-wrapper/panel-wrapper.component.html
@@ -1,4 +1,4 @@
-<div [fxHide]="shouldHide()">
+<div [fxHide]=hide>
   <mat-card class="mat-elevation-z0">
     <mat-card-header>
       <mat-card-title>{{ to.label }}</mat-card-title>

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/panel-wrapper/panel-wrapper.component.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/panel-wrapper/panel-wrapper.component.ts
@@ -1,12 +1,18 @@
-import { Component, OnInit } from '@angular/core';
+import {ChangeDetectionStrategy, Component, OnInit} from '@angular/core';
 import {FieldWrapper} from '@ngx-formly/core';
 
 @Component({
   selector: 'lib-panel-wrapper',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './panel-wrapper.component.html',
   styleUrls: ['./panel-wrapper.component.scss']
 })
-export class PanelWrapperComponent extends FieldWrapper {
+export class PanelWrapperComponent extends FieldWrapper implements OnInit {
+  hide: boolean;
+
+  ngOnInit() {
+    this.hide = this.shouldHide();
+  }
 
   // Loop through every field in group. If all are hidden, hide the group wrapper
    shouldHide(): boolean {
@@ -15,13 +21,14 @@ export class PanelWrapperComponent extends FieldWrapper {
        // Loop through every field in this field group.
        for (let x = 0; x < this.field.fieldArray.fieldGroup.length; x++) {
          // If we can find a hide expression in the field group...
-          if (typeof (this.field.fieldArray.fieldGroup[0].hideExpression) === 'function') {
+         let func = this.field.fieldArray.fieldGroup[x].hideExpression;
+          if (typeof(func) === 'function') {
             // Determine if this field is hidden. If not, then show the whole group
-            if ((this.field.fieldArray.fieldGroup[0].hideExpression(this.field.parent && this.field.parent.model, this.formState, this.field)) !== true) {
+            if ((func(this.field.parent && this.field.parent.model, this.formState, this.field)) !== true) {
             return false;
           }
             // is there even a hide expression in the fieldGroup? Then obviously don't hide it.
-        } else if (typeof (this.field.fieldArray.fieldGroup[0].hideExpression) === 'undefined') {
+        } else  {
           return false;
           }
       }

--- a/projects/sartography-workflow-lib/src/lib/modules/forms/repeat-section/repeat-section.component.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/repeat-section/repeat-section.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import {ChangeDetectionStrategy, Component} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { FieldArrayType, FormlyFieldConfig, FormlyFormOptions } from '@ngx-formly/core';
 import { RepeatSectionDialogData } from '../../../types/repeat-section-dialog-data';
@@ -10,6 +10,7 @@ import {clone, isNullOrUndefined} from '@ngx-formly/core/lib/utils';
 
 @Component({
   selector: 'lib-repeat-section',
+  changeDetection: ChangeDetectionStrategy.OnPush,
   templateUrl: './repeat-section.component.html',
   styleUrls: ['./repeat-section.component.scss'],
 })


### PR DESCRIPTION
In the panel component, the HTML was getting called every time to see if we needed to hide an entire repeat section. I changed this to onInit(). This might break a condition where you are showing a repeat section dynamically based on some other value, but it greatly reduces lagginess. The other thing is onPush() in the change detector ref, which helps a little bit