### PR TITLE
Validation fixes - companion to backend changes.

### DIFF
--- a/projects/sartography-workflow-lib/package.json
+++ b/projects/sartography-workflow-lib/package.json
@@ -1,5 +1,5 @@
 {
   "name": "sartography-workflow-lib",
-  "version": "0.0.607",
+  "version": "0.0.611",
   "dependencies": {}
 }

--- a/projects/sartography-workflow-lib/src/lib/components/api-errors/api-errors.component.html
+++ b/projects/sartography-workflow-lib/src/lib/components/api-errors/api-errors.component.html
@@ -10,12 +10,14 @@
       <mat-panel-title>
         <div class="title-section">
           <h4 *ngIf="e.code" class="title-case">{{snakeToSpace(e.code)}}</h4>
-          <div *ngIf="e.file_name">File: {{e.file_name}}</div>
-          <div *ngIf="e.task_name && e.task_id">{{e.task_name}} ({{e.task_id}})</div>
           <div *ngIf="e.task_id && !e.task_name">Task ID: {{e.task_id}}</div>
           <div *ngIf="e.task_name && !e.task_id">Task Name: {{e.task_name}}</div>
           <div *ngIf="e.tag">Tag: {{e.tag}}</div>
           <div *ngIf="e.line_number">Line #: {{e.line_number}}</div>
+          <div *ngIf="e.file_name">Task Trace(File):
+            <div *ngFor="let trace of e.task_trace">{{trace}}</div>
+          </div>
+
         </div>
       </mat-panel-title>
       <mat-panel-description>

--- a/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.ts
@@ -575,7 +575,7 @@ export class ToFormlyPipe implements PipeTransform {
 
     // If this is a single world (no spaces) and is a variable in the model, return it.
     // Also, handle any dot notation in the process.
-    if(expression.match(/^[\w_\-.]+$/) && model.hasOwnProperty(expression)) {
+    if(expression.match(/^[\w_\-.]+$/)) {
       return expression.split('.').reduce((o,i)=> o[i], model)
     }
 

--- a/projects/sartography-workflow-lib/src/lib/types/api.ts
+++ b/projects/sartography-workflow-lib/src/lib/types/api.ts
@@ -11,4 +11,5 @@ export interface ApiError {
   line_number: number;  // in multi line scripts, returns the line that contains an error, otherwise 0
   offset: number; // For syntax errors, returns the character in the line where the error happens, otherwise 0.
   error_line: string;
+  task_trace: string[]
 }


### PR DESCRIPTION
1. for expressions with dot notation, don't expect to find them in the model directly (they will be nested)
2. Provide the task trace if possible for any error messages.
All if this is bumped to 611.