### PR TITLE
FileNotFound error when publishing changes #690

### DIFF
--- a/projects/sartography-workflow-lib/src/lib/types/git.ts
+++ b/projects/sartography-workflow-lib/src/lib/types/git.ts
@@ -1,7 +1,8 @@
 export interface GitRepo {
   untracked?: string[];
   branch: string;
-  changes?: string[];
+  modified?: string[];
+  deleted?: string[];
   merge_branch: string;
   directory: string;
   display_push?: boolean;


### PR DESCRIPTION
Fix bug where we tried to `add` files that were deleted
We now pass deleted files separately in the git_repo API call