### PR TITLE
Python Expression Refactor

### DIFF
--- a/projects/sartography-workflow-lib/src/lib/modules/forms/repeat-section/repeat-section.component.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/forms/repeat-section/repeat-section.component.ts
@@ -39,7 +39,6 @@ export class RepeatSectionComponent extends FieldArrayType {
       options,
     };
     const cachedData: RepeatSectionDialogData = cloneDeep(dialogData);
-    console.log('Cache Data:', cachedData);
     const dialogRef = this.dialog.open(RepeatSectionDialogComponent, {
       maxWidth: '100vw',
       maxHeight: '100vh',
@@ -49,23 +48,17 @@ export class RepeatSectionComponent extends FieldArrayType {
 
     dialogRef.afterClosed().subscribe((model: any) => {
       if (model) {
-        console.log("This model is ", model)
         if (this.field.fieldGroup.length > i) {
-          console.log("Removing group")
           super.remove(i);
         }
-        console.log("This field is ", this.field)
-        console.log("updating model at ", i, model);
         super.add(i, model, {markAsDirty: true});
         this.changeDetector.detectChanges()
       }
 
       this.field.formControl.updateValueAndValidity();
       this.field.fieldGroup.forEach(fg => {
-        console.log("Field Groups are: ", fg);
         fg.formControl.updateValueAndValidity();
       })
-      console.log("The Model is ", this.field.parent.model)
     });
   }
 

--- a/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.spec.ts
+++ b/projects/sartography-workflow-lib/src/lib/modules/pipes/to-formly.pipe.spec.ts
@@ -4,16 +4,15 @@ import {MatBottomSheetModule} from '@angular/material/bottom-sheet';
 import {Router} from '@angular/router';
 import {ApiService} from '../../services/api.service';
 import {MockEnvironment} from '../../testing/mocks/environment.mocks';
-import {FileParams} from '../../types/file';
 import {BpmnFormJsonField} from '../../types/json';
 import {ToFormlyPipe} from './to-formly.pipe';
 import {APP_BASE_HREF} from '@angular/common';
-import {isBoolean} from "util";
+import {PythonService} from '../../services/python.service';
 
 describe('ToFormlyPipe', () => {
   let httpMock: HttpTestingController;
   let pipe: ToFormlyPipe;
-  let apiService: ApiService;
+  let pythonService: PythonService;
   const mockRouter = {navigate: jasmine.createSpy('navigate')};
   const workflowId = 20;
   const studyId = 15;
@@ -30,7 +29,7 @@ describe('ToFormlyPipe', () => {
         ToFormlyPipe,
       ],
       providers: [
-        ApiService,
+        PythonService,
         {provide: 'APP_ENVIRONMENT', useClass: MockEnvironment},
         {provide: APP_BASE_HREF, useValue: '/'},
         {provide: Router, useValue: mockRouter},
@@ -40,8 +39,8 @@ describe('ToFormlyPipe', () => {
 
   beforeEach(() => {
     httpMock = TestBed.inject(HttpTestingController);
-    apiService = TestBed.inject(ApiService);
-    pipe = new ToFormlyPipe(apiService);
+    pythonService = TestBed.inject(PythonService);
+    pipe = new ToFormlyPipe(pythonService);
   });
 
   it('should create a pipe instance', () => {

--- a/projects/sartography-workflow-lib/src/lib/services/piodide.service.spec.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/piodide.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PiodideService } from './piodide.service';
+
+describe('PiodideService', () => {
+  let service: PiodideService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PiodideService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/sartography-workflow-lib/src/lib/services/piodide.service.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/piodide.service.ts
@@ -1,0 +1,131 @@
+import { Injectable } from '@angular/core';
+import {ScriptService} from './script.service';
+import {defer, from, Observable} from 'rxjs';
+
+/**
+ * NOT CURRENTLY IN USE:
+ * Uses piodide (a Web Assembly based library) to execute python expressions or programs.
+ * This proved to be too slow to use in practice, so we had to go a different route for hide-expressions
+ * HOWEVER, I suspect this will be very useful to us in the BPMN editor at some point.  So keeping it around.
+ */
+@Injectable({providedIn: 'root'})
+export class PiodideService {
+  private pyodide: any
+  private readyPromise: Promise<any>
+
+  constructor(private scriptService: ScriptService) {
+    this.readyPromise = this.load();
+  }
+
+  /** Use this to determine if the service is ready for use.
+   */
+  public ready(): Observable<any> {
+    return defer(() => from(this.readyPromise));
+  }
+
+  public isReady() {
+    return this.pyodide != null
+  }
+
+  public async load() {
+    await this.scriptService.load('pyodide')
+    let loadPyodide = window["loadPyodide"];
+    let pyodide = await loadPyodide({
+      indexURL: "https://cdn.jsdelivr.net/pyodide/v0.19.1/full/",
+    });
+    this.pyodide = pyodide;
+    this.pyodide.runPython(this.python_box_class)
+    return pyodide;
+  }
+
+  eval(expression, context, defaultResult) {
+    if(this.pyodide == null) {
+      throw("Pyodide has not completed loading.")
+    }
+    try {
+      this.setContext(context)
+      let result = this.pyodide.runPython(expression);
+      return result
+    } catch (err) {
+      console.log("Failed to evaluate expression.", expression, err, context)
+      return defaultResult
+    }
+  }
+
+  setContext(context) {
+    this.pyodide.globals.set("my_globals", context)
+    this.pyodide.runPython(`
+globals_dict = my_globals.to_py()
+for k, v in globals_dict.items():
+    if isinstance(v, dict):
+        v = Box(v)
+    globals()[k] = v`);
+  }
+
+  /**
+   * Taken from SpiffWorkflow - this is a pythonic way to allow access to a dictionary with dot notation
+   * as well as a dictionary.  so my_box.attribute and my_box['attribute'] are the same thing.
+   */
+  private python_box_class = (`
+class Box(dict):
+  """
+  Example:
+  m = Box({'first_name': 'Eduardo'}, last_name='Pool', age=24, sports=['Soccer'])
+  """
+
+  def __init__(self, *args, **kwargs):
+      super(Box, self).__init__(*args, **kwargs)
+      for arg in args:
+          if isinstance(arg, dict):
+              for k, v in arg.items():
+                  if isinstance(v, dict):
+                      self[k] = Box(v)
+                  else:
+                      self[k] = v
+
+      if kwargs:
+          for k, v in kwargs.items():
+              if isinstance(v, dict):
+                  self[k] = Box(v)
+              else:
+                  self[k] = v
+
+  def __deepcopy__(self, memodict=None):
+      if memodict is None:
+          memodict = {}
+      my_copy = Box()
+      for k, v in self.items():
+          my_copy[k] = copy.deepcopy(v)
+      return my_copy
+
+  def __getattr__(self, attr):
+      try:
+          output = self[attr]
+      except:
+          raise AttributeError(
+              "Dictionary has no attribute '%s' " % str(attr))
+      return output
+
+  def __setattr__(self, key, value):
+      self.__setitem__(key, value)
+
+  def __setitem__(self, key, value):
+      super(Box, self).__setitem__(key, value)
+      self.__dict__.update({key: value})
+
+  def __getstate__(self):
+      return self.__dict__
+
+  def __setstate__(self, state):
+      self.__init__(state)
+
+  def __delattr__(self, item):
+      self.__delitem__(item)
+
+  def __delitem__(self, key):
+      super(Box, self).__delitem__(key)
+      del self.__dict__[key]
+
+`)
+
+}

--- a/projects/sartography-workflow-lib/src/lib/services/python.service.spec.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/python.service.spec.ts
@@ -1,0 +1,147 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PythonService } from './python.service';
+
+describe('PythonService', () => {
+  let service: PythonService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PythonService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should evaluate double quoted string expressions', () => {
+    expect(service.eval('"anything"', {})).toEqual('anything')
+  })
+
+  it('should evaluate single quoted string expressions', () => {
+    expect(service.eval('\'anything\'', {})).toEqual('anything')
+  })
+
+  it('should evaluate True / False', () => {
+    expect(service.eval('True', {})).toEqual(true)
+    expect(service.eval('False', {})).toEqual(false)
+  })
+
+  it('should evaluate numbers', () => {
+    expect(service.eval('1', {})).toEqual(1)
+  })
+
+  it('should evaluate variables', () => {
+    expect(service.eval('my_var', {'my_var': 'yo!'})).toEqual('yo!')
+  })
+
+  it('should handle the not opperator', () => {
+    expect(service.eval('not True', {})).toEqual(false)
+    expect(service.eval('not(True)', {})).toEqual(false)
+    expect(service.eval('not(var)', {"var":true})).toEqual(false)
+    expect(service.eval('not(var)', {"var":false})).toEqual(true)
+  })
+
+  it ('should disregard parens if completely surrounding an expression', () => {
+    expect(service.eval('("any old thing")', {})).toEqual("any old thing")
+  })
+
+
+  it ('should handle dot notation', () => {
+    let ctx = {"a": {"b": { "c": true }}}
+    expect(service.eval('a.b.c', ctx)).toEqual(true)
+    expect(service.eval('not a.b.c', ctx)).toEqual(false)
+  })
+
+  it ('should handle comparisons', () => {
+    expect(service.eval('1 == 2', {})).toEqual(false)
+    expect(service.eval('1 != 2', {})).toEqual(true)
+
+    let ctx = {"a": {"b": { "c": "Wilma", "d": "Fred"}}}
+    expect(service.eval('a.b.c == "Fred"', ctx)).toEqual(false)
+    expect(service.eval('a.b.c == "Wilma"', ctx)).toEqual(true)
+    expect(service.eval('a.b.c != a.b.d', ctx)).toEqual(true)
+  })
+
+  it ('should handle length expressions', () => {
+    expect(service.eval('len("apple")', {})).toEqual(5)
+    expect(service.eval('len(var)', {var:"apple"})).toEqual(5)
+  })
+
+  it ('should handle the "in" or includes operator', () => {
+    expect(service.eval('"a" in ["a","b"]', {})).toEqual(true)
+    expect(service.eval('"a" in ["b","c"]', {})).toEqual(false)
+  })
+
+  /*
+  CollStorUVaLocPaperTypes is None or "OtherTypes" not in CollStorUVaLocPaperTypes
+   */
+  it ('should handle the "not in" or includes operator', () => {
+    expect(service.eval('"a" not in ["a","b"]', {})).toEqual(false)
+    expect(service.eval('"a" not in ["b","c"]', {})).toEqual(true)
+  })
+
+/*
+  <camunda:property id="hide_expression" value="not AsApplConsentDocType or consent_docs[AsApplConsentDocType].has_description  != &#34;√&#34;" />
+  */
+  it ('should handle bracket notation.', () => {
+    let ctx = {"alpha":{"beta":{"gamma": "apple"}}, "var": "beta"}
+    expect(service.eval('alpha["beta"]["gamma"]', ctx)).toEqual("apple")
+    expect(service.eval('alpha[var]["gamma"]', ctx)).toEqual("apple")
+  })
+
+  /*  We need to support this use case I suspect.
+  it ('should handle get expressions within bracket notation.', () => {
+    let ctx = {"alpha":{"beta":{"gamma": "apple"}}, "var": "beta"}
+    expect(service.eval('alpha.get("beta").gamma', ctx)).toEqual("apple")
+  })
+   */
+
+  /*
+  <camunda:property id="hide_expression" value="CollStorUVaLocPaperTypes is None or &#34;OtherTypes&#34; not in CollStorUVaLocPaperTypes" />
+ */
+  it ('should handle is none.', () => {
+    let ctx = {"my_check": null}
+    expect(service.eval('my_check is None', ctx)).toEqual(true)
+  });
+
+/*
+    <camunda:property id="hide_expression" value="isIVRSIWRSIXRSMan or RequiredIVRS_IWRS_IXRS == &#34;no&#34; or RequiredIVRS_IWRS_IXRS is None" />
+ */
+  it ('should handle multiple or statements.', () => {
+    let ctx = {"a": null, "b": null, "c": 2}
+    expect(service.eval('a or b is not None or c == 2', ctx)).toEqual(true)
+  })
+
+  /*
+  "" if not AsApplAncillaryDocType else ancillary_docs[AsApplAncillaryDocType]["doczip"]
+  */
+  it ('should handle the if else expression', () => {
+    expect(service.eval('"x" if True else "y"', {})).toEqual(('x'))
+    expect(service.eval('"x" if False else "y"', {})).toEqual(('y'))
+    expect(service.eval('a if b else c', {"a":"a", "b": true, c:"c"})).toEqual(('a'))
+  })
+
+  it ('should handle some complex groupings of expressions', () => {
+    //  ex.  not var or var in ["a","b"]
+    expect(service.eval('x or var == "c"', {"x": true, "var": "a"})).toEqual(true)
+    expect(service.eval('x or var == "c"', {"x": false, "var": "c"})).toEqual(true)
+    expect(service.eval('x or var == "c"', {"x": false, "var": "a"})).toEqual(false)
+
+    expect(service.eval('not var or var in ["a","b"]', {"var": "a"})).toEqual(true)
+    expect(service.eval('not var or var in ["1","2"]', {"var": "c"})).toEqual(false)
+    expect(service.eval('not var or var in ["Z","X"]', {"var": null})).toEqual(true)
+
+    expect(service.eval('not var or var["var2"] != "b"', {"var": {"var2": "a"}})).toEqual(true)
+    expect(service.eval('not var or var["var2"] != "a"', {"var": {"var2": "a"}})).toEqual(false)
+
+  })
+
+  it ('should handle startswith method', () => {
+    expect(service.eval('"john".startswith("j")', {})).toEqual(true)
+    expect(service.eval('"john".startswith("Q")', {})).toEqual(false)
+    expect(service.eval('a.b.startswith("c")', {a: {b: "cat"}})).toEqual(true)
+    expect(service.eval('a.b.startswith(c)', {a: {b: "cat"}, c:"c"})).toEqual(true)
+  })
+
+});

--- a/projects/sartography-workflow-lib/src/lib/services/python.service.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/python.service.ts
@@ -1,0 +1,188 @@
+import { Injectable } from '@angular/core';
+import {ScriptService} from './script.service';
+import { cloneDeep } from 'lodash';
+import {defer, from, Observable, of} from 'rxjs';
+import {not} from 'rxjs/internal-compatibility';
+
+/**
+ * Does a very mediocre effort at evaluating short oneline python expressions in Javascript.
+ * I did this using Regular Expressions - which is a terrible way to go about this.  Would be far better to use a lexer.
+ * There are good tests, so this is really here to be re-written by a better person than I.
+ */
+@Injectable({providedIn: 'root'})
+export class PythonService {
+
+  constructor() {
+  }
+
+  isReady() {
+    // We are always ready baby. (here because we may want to switch out to the piodide service someday, which is
+    // definitely not "always ready"
+    return true
+  }
+
+  public ready(): Observable<any> {
+    return of(null)  // We are always ready.
+  }
+
+
+  /**
+   * I am ashamed of this method. It would be far better to tokenize and process.
+   * @param expression
+   * @param context
+   * @param defaultResult
+   */
+  eval(expression, context, defaultResult = "") {
+    expression = expression.trim()
+
+    // If this is True or False, just return that.
+    if (expression === 'True') return true;
+    if (expression === 'False') return false;
+    if (expression === 'None') return null;
+
+    // If this is just a double-quoted string, evaluate it to handle any escaped quotes.
+    let match = expression.match(/^"(?:[^"\\]|\\.)*"$/)
+    if (match) {
+      return eval(expression);
+    }
+
+    // If this is just a single-quoted string, evaluate it to handle any escaped quotes.
+    let quote_match = expression.match(/^'(?:[^'\\]|\\.)*'$/)
+    if (quote_match) {
+      return eval(expression);
+    }
+
+    // If this is just numbers, eval it.
+    let number_match = expression.match(/^\d+$/is)
+    if (number_match) {
+      return eval(expression);
+    }
+
+    // If this is a literal array, eval it.  ie ['a','b']
+    let array_match = expression.match(/^\[.*\]$/)
+    if (array_match) {
+      return eval(expression)
+    }
+
+    // If this is surrounded by parens, disregard them.
+    let paren_match = expression.match(/^\((.*)\)$/)
+    if (paren_match) {
+      return this.eval(paren_match[1], context);
+    }
+
+    // If this is a single world (no spaces).
+    // Also, handle any dot notation in the process.
+    if (expression.match(/^[\w_\-.]+$/)) {
+      return expression.split('.').reduce((o, i) => o[i], context)
+    }
+
+    // If this is an expression with bracket syntax, evaluate it.
+    // ie var1['property']  or v1['prop1']['subprop'] or even
+    // var1[var2]['subprop']
+    let braket_match = expression.match(/^(\w+)(\[[\w\'\"-_]+\])+$/)
+    if (braket_match) {
+      let my_value = context[braket_match[1]]
+      for (let match of expression.matchAll(/\[(['"]?)([\w-_]+)['"]?\]+/g)){
+        if(match[1]) {  // for x['y']  where 'y' is a string.
+          my_value = my_value[match[2]]
+        } else {        // for x[y] where y is a variable.
+          my_value = my_value[this.eval(match[2], context)]
+        }
+      }
+      return my_value
+    }
+
+    // if this is a start's with expression
+    let starts_with_match = expression.match(/^([\"\w\.]+)\.startswith\(((["']?)[^)]+\3)\)$/)
+    if (starts_with_match) {
+      let base = this.eval(starts_with_match[1], context)
+      let start = this.eval(starts_with_match[2], context)
+      return base.startsWith(start)
+    }
+
+    // If this is a get expression. ie dict.get('abc')
+/*
+    let get_match = expression.match(/^([\"\w\.]+)\.get\(((["']?)[^)]+\3)\)$/)
+    if (get_match) {
+      let base = this.eval(get_match[1], context)
+      let start = this.eval(get_match[2], context)
+      return base.get(start)
+    }
+*/
+
+    // If this is an expression that matches not XXX or not(XXX), where XXX is in the model, eval that.
+    let not_match = expression.match(/^not[ \(]([\w\.]+)\)?$/)
+    if (not_match) {
+      let base = this.eval(not_match[1], context)
+      if (base == null) {
+        return true
+      } else {
+        return !(base)
+      }
+    }
+
+    let len_match = expression.match(/^len\((.+)\)$/)
+    if (len_match) {
+      return this.eval(len_match[1], context).length
+    }
+
+    let if_else_match = expression.match(/^(.*) if (.*) else (.*)$/)
+    if (if_else_match) {
+      let condition = this.eval(if_else_match[2], context)
+      if(condition) {
+        return this.eval(if_else_match[1], context)
+      } else {
+        return this.eval(if_else_match[3], context)
+      }
+    }
+
+    let or_match = expression.match(/(.*) (or) ?(.*)$/)
+    if (or_match) {
+      let arg1 = this.eval(or_match[1], context)
+      if (arg1) {
+        return arg1
+      } else {
+        return this.eval(or_match[3], context)
+      }
+    }
+
+
+    // If this contains a comparison, split, eval each side, and compare the two.
+    // Perfer to split on comparisons first.
+    let compare_match = expression.match(/(.*) ?(==|!=| is ) ?(.*)$/)
+    if (compare_match) {
+      let arg1 = this.eval(compare_match[1], context)
+      let arg2 = this.eval(compare_match[3], context)
+      let comp = compare_match[2]
+      if (comp == '!=')
+        return arg1 !== arg2
+      else
+        return arg1 === arg2
+    }
+
+    let not_in_match = expression.match(/(.*) ?( not in ) ?(.*)$/)
+    if (not_in_match) {
+      let arg1 = this.eval(not_in_match[1], context)
+      let arg2 = this.eval(not_in_match[3], context)
+      return !arg2.includes(arg1)
+    }
+
+    let and_in_match = expression.match(/(.*) ?( and | in ) ?(.*)$/)
+    if (and_in_match) {
+      let arg1 = this.eval(and_in_match[1], context)
+      let arg2 = this.eval(and_in_match[3], context)
+      let comp = and_in_match[2]
+      if (comp == ' and ')
+        return arg1 && arg2
+      else if (comp == ' in ')
+        return arg2.includes(arg1)
+    }
+
+    if (defaultResult === "no_default") {
+      throw SyntaxError("unable to evaluate expression " + expression)
+    } else {
+      console.error("Failed to parse expression ", expression)
+      return defaultResult
+    }
+  }
+}1

--- a/projects/sartography-workflow-lib/src/lib/services/python.service.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/python.service.ts
@@ -185,4 +185,4 @@ export class PythonService {
       return defaultResult
     }
   }
-}1
+}

--- a/projects/sartography-workflow-lib/src/lib/services/script.service.spec.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/script.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ScriptService } from './script.service';
+
+describe('ScriptService', () => {
+  let service: ScriptService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ScriptService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/projects/sartography-workflow-lib/src/lib/services/script.service.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/script.service.ts
@@ -1,0 +1,66 @@
+import {Injectable} from "@angular/core";
+import {ScriptStore} from './script.store';
+
+declare var document: any;
+
+@Injectable({providedIn: 'root'})
+export class ScriptService {
+  /**
+   * NOT CURRENTLY IN USE:
+   * *
+   * This script service can be injected to load up externally referenced javascript libraries
+   * from a CDN (content delivery network).  For really large libraries (like pyodide for python
+   * processing) this makes loading the libraries a lot faster, and reduces the overall load time
+   * of this library and whatever it is injected into.
+   * @private
+   */
+
+  private scripts: any = {};
+
+  constructor() {
+    ScriptStore.forEach((script: any) => {
+      this.scripts[script.name] = {
+        loaded: false,
+        src: script.src
+      };
+    });
+  }
+
+  load(...scripts: string[]) {
+    var promises: any[] = [];
+    scripts.forEach((script) => promises.push(this.loadScript(script)));
+    return Promise.all(promises);
+  }
+
+  loadScript(name: string) {
+    return new Promise((resolve, reject) => {
+      //resolve if already loaded
+      if (this.scripts[name].loaded) {
+        resolve({script: name, loaded: true, status: 'Already Loaded'});
+      }
+      else {
+        //load script
+        let script = document.createElement('script');
+        script.type = 'text/javascript';
+        script.src = this.scripts[name].src;
+        if (script.readyState) {  //IE
+          script.onreadystatechange = () => {
+            if (script.readyState === "loaded" || script.readyState === "complete") {
+              script.onreadystatechange = null;
+              this.scripts[name].loaded = true;
+              resolve({script: name, loaded: true, status: 'Loaded'});
+            }
+          };
+        } else {  //Others
+          script.onload = () => {
+            this.scripts[name].loaded = true;
+            resolve({script: name, loaded: true, status: 'Loaded'});
+          };
+        }
+        script.onerror = (error: any) => resolve({script: name, loaded: false, status: 'Loaded'});
+        document.getElementsByTagName('head')[0].appendChild(script);
+      }
+    });
+  }
+
+}

--- a/projects/sartography-workflow-lib/src/lib/services/script.store.ts
+++ b/projects/sartography-workflow-lib/src/lib/services/script.store.ts
@@ -1,0 +1,12 @@
+interface Scripts {
+  name: string;
+  src: string;
+}
+
+/**
+ * related to the Script Service - Define any external libraries provided over a CDN here,
+ * and the Script Service will be able to load them up for you.
+ */
+export const ScriptStore: Scripts[] = [
+  {name: 'pyodide', src: 'https://cdn.jsdelivr.net/pyodide/v0.19.1/full/pyodide.js'},
+];

--- a/projects/sartography-workflow-lib/src/public-api.ts
+++ b/projects/sartography-workflow-lib/src/public-api.ts
@@ -43,6 +43,8 @@ export * from './lib/services/auth-interceptor';
 export * from './lib/services/error-interceptor';
 export * from './lib/services/google-analytics.service';
 export * from './lib/services/interval/interval.service';
+export * from './lib/services/python.service';
+export * from './lib/services/piodide.service';
 
 // Static Files
 export * from './lib/static/bpmn';


### PR DESCRIPTION
Removing all backend calls for python execution that are related to hide expressions, default values, labels, and other expressions set in Formly.  These methods get called 1000's of times on some pages.

All new working code is in the python.service with good tests in the python.service.spec.
Also included here, but not used, is the piodide service which can execute python using web assembly, but proved to be too slow for hide expressions, but which could be very useful for our BPMN editor.  Also included, but not currently in use is the script service, which can be used to load large librarires (like piodide) over a CDN to make loading far more efficient.